### PR TITLE
Fix code coverage generation

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,8 +3,8 @@
 [![Azure DevOps][azuredevopslogo]][azuredevopslink]
 [![GitHub Actions][githubactionslogo]][githubactionslink]
 
+[![Code coverage][coveragelogo]][coveragelink]
 [![Sonar Quality][sonarqualitylogo]][sonarqubelink]
-[![Code coverage][sonarcoveragelogo]][sonarqubelink]
 [![Sonar vulnerabilities][sonarvulnerabilitieslogo]][sonarqubelink]
 [![Sonar bugs][sonarbugslogo]][sonarqubelink]
 [![Sonar code smells][sonarcodesmellslogo]][sonarqubelink]
@@ -235,9 +235,10 @@ Depends on [XUnit](https://xunit.net/).
 [nugetlink-moq]: https://www.nuget.org/packages/SheepTools.Moq
 [nugetlogo-xunit]: https://img.shields.io/nuget/v/SheepTools.XUnit.svg?style=flat-square&label=nuget
 [nugetlink-xunit]: https://www.nuget.org/packages/SheepTools.XUnit
+[coveragelogo]: https://img.shields.io/azure-devops/coverage/eduherminio/Sheeptools/8/master
+[coveragelink]: https://dev.azure.com/eduherminio/SheepTools/_build/latest?definitionId=8&branchName=master
 [sonarqubelink]: https://sonarcloud.io/dashboard?id=SheepTools
 [sonarqualitylogo]: https://sonarcloud.io/api/project_badges/measure?project=SheepTools&metric=alert_status
-[sonarcoveragelogo]: https://sonarcloud.io/api/project_badges/measure?project=SheepTools&metric=coverage
 [sonarvulnerabilitieslogo]: https://sonarcloud.io/api/project_badges/measure?project=SheepTools&metric=vulnerabilities
 [sonarbugslogo]: https://sonarcloud.io/api/project_badges/measure?project=SheepTools&metric=bugs
 [sonarcodesmellslogo]: https://sonarcloud.io/api/project_badges/measure?project=SheepTools&metric=code_smells

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -4,6 +4,7 @@ trigger:
   branches:
     include:
     - master
+    - fix-coverage
 
 stages:
 - stage: CI
@@ -53,7 +54,7 @@ stages:
       displayName: 'Build'
       inputs:
         command: build
-        arguments: '--configuration Release --no-restore /p:ContinuousIntegrationBuild=true'
+        arguments: '--configuration Release --no-restore /p:ContinuousIntegrationBuild=false'
         projects: 'SheepToolsSolution.sln'
 
     - task: DotNetCoreCLI@2

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -4,7 +4,14 @@ trigger:
   branches:
     include:
     - master
-    - fix-coverage
+
+schedules:
+- cron: "1 0 * * 1"
+  displayName: 'Weekly midnight build'
+  always: true
+  branches:
+    include:
+    - master
 
 stages:
 - stage: CI


### PR DESCRIPTION
* Fix coverage generation in Azure DevOps by using `/p:ContinuousIntegrationBuild=false` in CI stage.
* Add weekly scheduled CI run.
* Show Azure DevOps code coverage badge, rather than SonarCloud one, that just stopped working.