### PR TITLE
Add ReportGenerator to GitHub Actions CI 

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -68,12 +68,12 @@ jobs:
       with:
         reports: 'tests/**/*.cobertura.xml'
         targetdir: 'coveragereport'
-        reporttypes: HtmlInline_AzurePipelines_Dark'
+        reporttypes: 'HtmlInline_AzurePipelines_Dark'
         assemblyfilters: '+*'
         classfilters: '+*'
         filefilters: '+*'
         verbosity: 'Info'
-        title: 'SheepTools coverage #${{ github.run_number }} (${{ env.GITHUB_REF_SLUG }})'
+        title: 'SheepTools #${{ github.run_number }} (${{ env.GITHUB_REF_SLUG }})'
         tag: '${{ github.run_number }}_${{ github.run_id }}'
         customSettings: 'numberOfReportsParsedInParallel=3;numberOfReportsMergedInParallel=3'
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -67,7 +67,7 @@ jobs:
       if: matrix.os == 'ubuntu-latest'
       uses: danielpalme/ReportGenerator-GitHub-Action@4.8.0
       with:
-        reports: 'tests/TestResults/**/*.cobertura.xml'
+        reports: 'tests/**/TestResults/*.cobertura.xml'
         targetdir: 'coveragereport'
         reporttypes: 'Cobertura'
         assemblyfilters: '+*'

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -42,7 +42,6 @@ jobs:
       run: dotnet build -c Release /p:DeterministicBuild=true
 
     - name: Run tests
-      if: matrix.os != 'ubuntu-latest'
       run: dotnet test -c Release --no-build --collect:"XPlat Code Coverage"
 
     - name: '[Ubuntu] Pack'

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -42,7 +42,7 @@ jobs:
       if: matrix.os != 'ubuntu-latest'
       run: dotnet test -c Release --no-build
 
-    - name: Run tests with coverage
+    - name: '[Ubuntu] Run tests with coverage'
       if: matrix.os == 'ubuntu-latest'
       run: dotnet test -c Release --no-build --collect:"XPlat Code Coverage"
 
@@ -63,7 +63,7 @@ jobs:
           ${{ env.ARTIFACT_DIR }}/*.snupkg
         if-no-files-found: error
 
-    - name: ReportGenerator
+    - name: '[Ubuntu] ReportGenerator'
       if: matrix.os == 'ubuntu-latest'
       uses: danielpalme/ReportGenerator-GitHub-Action@4.8.0
       with:
@@ -75,5 +75,13 @@ jobs:
         filefilters: '+*'
         verbosity: 'Info'
         title: 'SheepTools coverage #${{ github.run_number }}'
-        tag: '${{ github.run_number }}_${{ github.run_id }}' # Optional tag or build version.
-        customSettings: 'numberOfReportsParsedInParallel=3;numberOfReportsMergedInParallel=3' # Optional custom settings (separated by semicolon). See: https://github.com/danielpalme/ReportGenerator/wiki/Settings.
+        tag: '${{ github.run_number }}_${{ github.run_id }}'
+        customSettings: 'numberOfReportsParsedInParallel=3;numberOfReportsMergedInParallel=3'
+
+    - name: '[Ubuntu] Upload coverage report'
+      if: matrix.os == 'ubuntu-latest'
+      uses: actions/upload-artifact@v2
+      with:
+        name: SheepTools-coverage-${{ github.run_number }}
+        path: coveragereport/*.xml
+        if-no-files-found: error

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -67,7 +67,7 @@ jobs:
       if: matrix.os == 'ubuntu-latest'
       uses: danielpalme/ReportGenerator-GitHub-Action@4.8.0
       with:
-        reports: 'tests/**/TestResults/*.cobertura.xml'
+        reports: 'tests/**/*.cobertura.xml'
         targetdir: 'coveragereport'
         reporttypes: 'Cobertura'
         assemblyfilters: '+*'

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -69,7 +69,7 @@ jobs:
       with:
         reports: 'tests/**/*.cobertura.xml'
         targetdir: 'coveragereport'
-        reporttypes: 'Cobertura'
+        reporttypes: 'Html;HtmlChart;HtmlInline;HtmlInline_AzurePipelines;HtmlInline_AzurePipelines_Dark;HtmlSummary;Badges;SonarQube;PngChart'
         assemblyfilters: '+*'
         classfilters: '+*'
         filefilters: '+*'
@@ -83,5 +83,5 @@ jobs:
       uses: actions/upload-artifact@v2
       with:
         name: SheepTools-coverage-${{ github.run_number }}
-        path: coveragereport/*.xml
+        path: coveragereport/
         if-no-files-found: error

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -38,8 +38,13 @@ jobs:
     - name: Build
       run: dotnet build -c Release /p:DeterministicBuild=true
 
-    - name: Run tests
+    - name: Run tests without coverage
+      if: matrix.os != 'ubuntu-latest'
       run: dotnet test -c Release --no-build
+
+    - name: Run tests with coverage
+      if: matrix.os == 'ubuntu-latest'
+      run: dotnet test -c Release --no-build --collect:"XPlat Code Coverage"
 
     - name: '[Ubuntu] Pack'
       if: matrix.os == 'ubuntu-latest'
@@ -57,3 +62,18 @@ jobs:
           ${{ env.ARTIFACT_DIR }}/*.nupkg
           ${{ env.ARTIFACT_DIR }}/*.snupkg
         if-no-files-found: error
+
+    - name: ReportGenerator
+      if: matrix.os == 'ubuntu-latest'
+      uses: danielpalme/ReportGenerator-GitHub-Action@4.8.0
+      with:
+        reports: 'tests/TestResults/**/*.cobertura.xml'
+        targetdir: 'coveragereport'
+        reporttypes: 'Cobertura'
+        assemblyfilters: '+*'
+        classfilters: '+*'
+        filefilters: '+*'
+        verbosity: 'Info'
+        title: 'SheepTools coverage #${{ github.run_number }}'
+        tag: '${{ github.run_number }}_${{ github.run_id }}' # Optional tag or build version.
+        customSettings: 'numberOfReportsParsedInParallel=3;numberOfReportsMergedInParallel=3' # Optional custom settings (separated by semicolon). See: https://github.com/danielpalme/ReportGenerator/wiki/Settings.

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,6 +22,9 @@ jobs:
     steps:
     - uses: actions/checkout@v2.3.3
 
+    - name: Inject slug/short variables
+      uses: rlespinasse/github-slug-action@v3.x
+
     - name: Setup .NET Core
       uses: actions/setup-dotnet@v1.7.2
       with:
@@ -38,12 +41,8 @@ jobs:
     - name: Build
       run: dotnet build -c Release /p:DeterministicBuild=true
 
-    - name: Run tests without coverage
+    - name: Run tests
       if: matrix.os != 'ubuntu-latest'
-      run: dotnet test -c Release --no-build
-
-    - name: '[Ubuntu] Run tests with coverage'
-      if: matrix.os == 'ubuntu-latest'
       run: dotnet test -c Release --no-build --collect:"XPlat Code Coverage"
 
     - name: '[Ubuntu] Pack'
@@ -63,18 +62,18 @@ jobs:
           ${{ env.ARTIFACT_DIR }}/*.snupkg
         if-no-files-found: error
 
-    - name: '[Ubuntu] ReportGenerator'
+    - name: '[Ubuntu] Generate test coverage report'
       if: matrix.os == 'ubuntu-latest'
       uses: danielpalme/ReportGenerator-GitHub-Action@4.8.0
       with:
         reports: 'tests/**/*.cobertura.xml'
         targetdir: 'coveragereport'
-        reporttypes: 'Html;HtmlChart;HtmlInline;HtmlInline_AzurePipelines;HtmlInline_AzurePipelines_Dark;HtmlSummary;Badges;SonarQube;PngChart'
+        reporttypes: HtmlInline_AzurePipelines_Dark'
         assemblyfilters: '+*'
         classfilters: '+*'
         filefilters: '+*'
         verbosity: 'Info'
-        title: 'SheepTools coverage #${{ github.run_number }}'
+        title: 'SheepTools coverage #${{ github.run_number }} (${{ env.GITHUB_REF_SLUG }})'
         tag: '${{ github.run_number }}_${{ github.run_id }}'
         customSettings: 'numberOfReportsParsedInParallel=3;numberOfReportsMergedInParallel=3'
 


### PR DESCRIPTION
Add test coverage report generation to CI pipeline in GitHub Actions (using [ReportGenerator](https://github.com/danielpalme/ReportGenerator)).